### PR TITLE
Update ensemble ui with clickable providers

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -335,12 +335,13 @@ const App = () => {
   }, [messages]);
 
   const buildEligibleMapForRound = useCallback((userTurnId: string): {
-    map: Record<string, { disabled: boolean; reason?: string }>;
+    synthMap: Record<string, { disabled: boolean; reason?: string }>;
+    ensembleMap: Record<string, { disabled: boolean; reason?: string }>;
     disableSynthesisRun: boolean;
     disableEnsembleRun: boolean;
   } => {
     const round = findRoundForUserTurn(userTurnId);
-    if (!round) return { map: {}, disableSynthesisRun: true, disableEnsembleRun: true };
+    if (!round) return { synthMap: {}, ensembleMap: {}, disableSynthesisRun: true, disableEnsembleRun: true };
 
     const { aiIndex, ai } = round;
     const outputs = Object.values(ai?.providerResponses || {}).filter(r => r.status === 'completed' && r.text?.trim());
@@ -349,27 +350,47 @@ const App = () => {
     const existingSynth = findExistingSynthesisTurnForRound(userTurnId);
     const alreadySynthPids = existingSynth ? Object.keys(existingSynth.turn.providerResponses || {}) : [];
 
-    const map: Record<string, { disabled: boolean; reason?: string }> = {};
+    // Build eligibility map for Synthesis (multi-select)
+    const synthMap: Record<string, { disabled: boolean; reason?: string }> = {};
     LLM_PROVIDERS_CONFIG.forEach(p => {
       const contAfter = providerHasActivityAfter(p.id, aiIndex);
       const alreadySynth = alreadySynthPids.includes(p.id);
       if (!enoughOutputs) {
-        map[p.id] = { disabled: true, reason: 'Need ≥ 2 model outputs in this round' };
+        synthMap[p.id] = { disabled: true, reason: 'Need ≥ 2 model outputs in this round' };
       } else if (contAfter) {
-        map[p.id] = { disabled: true, reason: 'Provider continued after this round' };
+        synthMap[p.id] = { disabled: true, reason: 'Provider continued after this round' };
       } else if (alreadySynth) {
-        map[p.id] = { disabled: true, reason: 'Already synthesized for this round' };
+        synthMap[p.id] = { disabled: true, reason: 'Already synthesized for this round' };
       } else {
-        map[p.id] = { disabled: false };
+        synthMap[p.id] = { disabled: false };
+      }
+    });
+
+    // Build eligibility map for Ensemble (single-select)
+    const existingEnsemble = findExistingEnsembleTurnForRound(userTurnId);
+    const alreadyEnsemblePids = existingEnsemble ? Object.keys(existingEnsemble.turn.providerResponses || {}) : [];
+    const ensembleMap: Record<string, { disabled: boolean; reason?: string }> = {};
+    LLM_PROVIDERS_CONFIG.forEach(p => {
+      const contAfter = providerHasActivityAfter(p.id, aiIndex);
+      const alreadyEnsembled = alreadyEnsemblePids.includes(p.id);
+      if (!enoughOutputs) {
+        ensembleMap[p.id] = { disabled: true, reason: 'Need ≥ 2 model outputs in this round' };
+      } else if (contAfter) {
+        ensembleMap[p.id] = { disabled: true, reason: 'Provider continued after this round' };
+      } else if (alreadyEnsembled) {
+        ensembleMap[p.id] = { disabled: true, reason: 'Already ensembled for this round' };
+      } else {
+        ensembleMap[p.id] = { disabled: false };
       }
     });
 
     return {
-      map,
+      synthMap,
+      ensembleMap,
       disableSynthesisRun: !enoughOutputs,
       disableEnsembleRun: !enoughOutputs,
     };
-  }, [findRoundForUserTurn, findExistingSynthesisTurnForRound, providerHasActivityAfter]);
+  }, [findRoundForUserTurn, findExistingSynthesisTurnForRound, findExistingEnsembleTurnForRound, providerHasActivityAfter]);
 
   // ===== Round bar handlers =====
   const handleToggleSynthForRound = useCallback((userTurnId: string, providerId: string) => {
@@ -1326,8 +1347,12 @@ ${modelOutputsBlock}`;
 
           requestAnimationFrame(() => {
             try { listRef.current?.resetAfterIndex(index, true); } catch {}
-            if (outer && isMidScroll) {
-              outer.scrollTop += delta;
+            if (outer) {
+              if (scrollBottomRef.current) {
+                outer.scrollTop = outer.scrollHeight - outer.clientHeight;
+              } else if (isMidScroll) {
+                outer.scrollTop += delta;
+              }
             }
           });
         }
@@ -1340,7 +1365,7 @@ ${modelOutputsBlock}`;
     }, [index, turn && turn.id, expandedUserTurns[turn?.id || ''] , isReducedMotion, currentAppStep]);
 
     if (turn && isUserTurn(turn)) {
-      const { map, disableSynthesisRun, disableEnsembleRun } = buildEligibleMapForRound(turn.id);
+      const { synthMap, ensembleMap, disableSynthesisRun, disableEnsembleRun } = buildEligibleMapForRound(turn.id);
       return (
         <div style={style}>
           <div ref={containerRef} style={{ padding: '8px 0' }}>
@@ -1354,7 +1379,8 @@ ${modelOutputsBlock}`;
               ensembleSelected={ensembleSelectionByRound[turn.id] || null}
               onSelectEnsemble={handleSelectEnsembleForRound}
               onRunEnsemble={handleRunEnsembleForRound}
-              eligibleMap={map}
+              eligibleMap={synthMap}
+              ensembleEligibleMap={ensembleMap}
               disableSynthesisRun={disableSynthesisRun}
               disableEnsembleRun={disableEnsembleRun}
             />

--- a/ui/components/TurnActionBar.tsx
+++ b/ui/components/TurnActionBar.tsx
@@ -18,6 +18,8 @@ interface TurnActionBarProps {
 
   // Per-provider grey-out
   eligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
+  // Ensemble-specific grey-out (separate from synthesis)
+  ensembleEligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
 
   // Optional guards
   disableSynthesisRun?: boolean;
@@ -34,6 +36,7 @@ const TurnActionBar = ({
   onSelectEnsemble,
   onRunEnsemble,
   eligibleMap = {},
+  ensembleEligibleMap = {},
   disableSynthesisRun = false,
   disableEnsembleRun = false,
 }: TurnActionBarProps) => {
@@ -42,7 +45,8 @@ const TurnActionBar = ({
     isSelected: boolean,
     onClick: () => void,
     isDisabled: boolean,
-    title: string
+    title: string,
+    accentHex?: string
   ) => (
     <button
       key={pid}
@@ -55,12 +59,15 @@ const TurnActionBar = ({
         gap: 6,
         padding: '6px 10px',
         borderRadius: 999,
-        border: '1px solid #475569',
-        background: isSelected ? '#334155' : '#0f172a',
+        border: isSelected && accentHex ? `1px solid ${accentHex}` : '1px solid #475569',
+        background: isSelected
+          ? (accentHex ? 'rgba(16,185,129,0.12)' : '#334155')
+          : '#0f172a',
         color: isDisabled ? '#64748b' : '#e2e8f0',
         opacity: isDisabled ? 0.6 : 1,
         fontSize: 12,
-        cursor: (isDisabled || isLoading) ? 'not-allowed' : 'pointer'
+        cursor: (isDisabled || isLoading) ? 'not-allowed' : 'pointer',
+        boxShadow: isSelected && accentHex ? `0 0 0 2px ${accentHex}20` : undefined,
       }}
     >
       {isSelected ? '✓' : '○'} {LLM_PROVIDERS_CONFIG.find(p => p.id === pid)?.name || pid}
@@ -114,12 +121,16 @@ const TurnActionBar = ({
         <span style={{ color: '#94a3b8', fontSize: 12 }}>Ensemble with:</span>
         {LLM_PROVIDERS_CONFIG.map(p => {
           const isSelected = ensembleSelected === p.id;
+          const block = ensembleEligibleMap[p.id];
+          const isDisabled = !!block?.disabled;
+          const title = block?.reason ? `${p.name}: ${block.reason}` : `Choose ${p.name} to ensemble`;
           return renderToggle(
             p.id,
             isSelected,
             () => onSelectEnsemble(roundUserTurnId, p.id),
-            false,
-            `Choose ${p.name} to ensemble`
+            isDisabled,
+            title,
+            '#10b981'
           );
         })}
         <div style={{ flex: 1 }} />

--- a/ui/components/UserTurnBlock.tsx
+++ b/ui/components/UserTurnBlock.tsx
@@ -51,11 +51,12 @@ interface UserTurnBlockProps {
   onSelectEnsemble?: (roundUserTurnId: string, providerId: string) => void;
   onRunEnsemble?: (roundUserTurnId: string) => void;
   eligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
+  ensembleEligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
   disableSynthesisRun?: boolean;
   disableEnsembleRun?: boolean;
 }
 
-const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onToggleSynth, onRunSynthesis, ensembleSelected = null, onSelectEnsemble, onRunEnsemble, eligibleMap = {}, disableSynthesisRun = false, disableEnsembleRun = false }: UserTurnBlockProps) => {
+const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onToggleSynth, onRunSynthesis, ensembleSelected = null, onSelectEnsemble, onRunEnsemble, eligibleMap = {}, ensembleEligibleMap = {}, disableSynthesisRun = false, disableEnsembleRun = false }: UserTurnBlockProps) => {
   const date = new Date(userTurn.createdAt);
   const readableTimestamp = date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
   const isoTimestamp = date.toISOString();
@@ -169,6 +170,7 @@ const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onT
             onSelectEnsemble={onSelectEnsemble!}
             onRunEnsemble={onRunEnsemble!}
             eligibleMap={eligibleMap}
+            ensembleEligibleMap={ensembleEligibleMap}
             disableSynthesisRun={disableSynthesisRun}
             disableEnsembleRun={disableEnsembleRun}
           />


### PR DESCRIPTION
Add visual cues and disable states for ensemble provider selection, and prevent viewport jumps when interacting with ensemble toggles.

The ensemble feature lacked visual feedback for selected/disabled providers and caused disruptive viewport jumps when users interacted with the toggles. This PR addresses these issues by providing clear visual states and stabilizing the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e384465-db4d-4cc9-a695-ec478a8ecef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e384465-db4d-4cc9-a695-ec478a8ecef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

