### PR TITLE
Complete think mode integration for ui

### DIFF
--- a/src/sw-entry.js
+++ b/src/sw-entry.js
@@ -1132,7 +1132,7 @@ chrome.runtime.onConnect.addListener((port) => {
        }
 
       if (message.type === "continue") {
-        const { prompt, providers, sessionId, providerContexts } = message;
+        const { prompt, providers, sessionId, providerContexts, useThinking } = message;
         console.log(`[HTOS] Processing continuation for session ${sessionId} with ${providers.length} providers`);
 
         // Validate providers
@@ -1168,6 +1168,13 @@ chrome.runtime.onConnect.addListener((port) => {
               ...storedContexts[providerId]?.meta
             }
           };
+          // Thread useThinking into meta (session-level preference for this continuation)
+          try {
+            mergedContexts[providerId].meta = {
+              ...(mergedContexts[providerId].meta || {}),
+              useThinking: Boolean(useThinking)
+            };
+          } catch {}
         }
         
         console.log("[HTOS] Merged provider contexts for continuation:", mergedContexts);
@@ -1303,6 +1310,7 @@ chrome.runtime.onConnect.addListener((port) => {
         try {
           let sessionId = message.sessionId || `wf-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
           const isHidden = false; // hidden synthesis disabled
+          const useThinking = Boolean(message.useThinking);
 
           // Normalize providers: support single provider (legacy) or array (batch)
           const singleProvider = (message.provider ? String(message.provider) : (message.synthesisProvider ? String(message.synthesisProvider) : "")).toLowerCase();
@@ -1389,6 +1397,10 @@ chrome.runtime.onConnect.addListener((port) => {
                 meta.parentMessageId = synthMeta.parentMessageId;
                 meta.messageId = synthMeta.messageId;
               }
+              // Honor Think-mode for ChatGPT synthesis
+              if (synthesisProvider === 'chatgpt' && useThinking) {
+                meta.useThinking = true;
+              }
 
               // Execute synthesis for this provider
               const res = await self.orchestrator.batchPrompt(originalPrompt, {
@@ -1471,7 +1483,7 @@ chrome.runtime.onConnect.addListener((port) => {
       // FINAL ENSEMBLING (Round 3) — stream a single visible answer from chosen provider
       if (message.type === 'ensemble_finalize') {
         try {
-          const { sessionId, userPrompt, modelOutputs, ensemblerProvider, ensemblerPrompt } = message;
+          const { sessionId, userPrompt, modelOutputs, ensemblerProvider, ensemblerPrompt, useThinking } = message;
           const providerId = String(ensemblerProvider || 'claude').toLowerCase();
           const adapter = providerRegistry.getAdapter(providerId);
           if (!adapter) {
@@ -1488,6 +1500,7 @@ chrome.runtime.onConnect.addListener((port) => {
               ensemble: true,
               userPrompt,
               modelOutputs,
+              ...(providerId === 'chatgpt' ? { useThinking: Boolean(useThinking) } : {})
             },
           };
 

--- a/src/think/server/lib/think/emitToolThinking.js
+++ b/src/think/server/lib/think/emitToolThinking.js
@@ -1,5 +1,5 @@
-import { ndjsonSerialize } from '../../../src/lib/think/ndjson.js';
-import { O1_TOOL_NAME } from '../../../src/lib/think/constants.js';
+import { ndjsonSerialize } from '../../../lib/think/ndjson.js';
+import { O1_TOOL_NAME } from '../../../lib/think/constants.js';
 import crypto from 'crypto';
 
 // emits a single NDJSON line representing a Harpa-compatible tool message "🤔 Thinking..."

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -3,6 +3,7 @@ import { VariableSizeList as List, ListChildComponentProps } from 'react-window'
 import React from 'react';
 import { TurnMessage, UserTurn, AiTurn, ProviderResponse, AppStep, ChatSession, BackendMessage, LLMProvider, isUserTurn, isAiTurn, UiPhase, BackendFullSession } from './types';
 import { LLM_PROVIDERS_CONFIG, EXAMPLE_PROMPT } from './constants';
+import { computeThinkFlag } from '../src/think/lib/think/computeThinkFlag.js';
 import UserTurnBlock from './components/UserTurnBlock';
 import AiTurnBlock from './components/AiTurnBlock';
 import ChatInput from './components/ChatInput';
@@ -89,6 +90,10 @@ const App = () => {
   // Round-level action bar selections
   const [synthSelectionsByRound, setSynthSelectionsByRound] = useState<Record<string, Record<string, boolean>>>({});
   const [ensembleSelectionByRound, setEnsembleSelectionByRound] = useState<Record<string, string | null>>({});
+  // Think toggles
+  const [thinkOnChatGPT, setThinkOnChatGPT] = useState<boolean>(false);
+  const [thinkSynthByRound, setThinkSynthByRound] = useState<Record<string, boolean>>({});
+  const [thinkEnsembleByRound, setThinkEnsembleByRound] = useState<Record<string, boolean>>({});
 
   // Refs
   const activeAiTurnIdRef = useRef<string | null>(null);
@@ -488,7 +493,14 @@ const App = () => {
         setLastSynthesisModel(normalized[0]);
       }
       // fan-out supported by backend API; pass array when >1
-      await api.executeSynthesis(currentSessionId, originalPrompt, results, normalized.length === 1 ? normalized[0] : normalized, uiTabId, { idempotencyToken });
+      await api.executeSynthesis(
+        currentSessionId,
+        originalPrompt,
+        results,
+        normalized.length === 1 ? normalized[0] : normalized,
+        uiTabId,
+        { idempotencyToken, useThinking: !!thinkSynthByRound[userTurnId] && normalized.includes('chatgpt') }
+      );
     } catch (err) {
       console.error('Synthesis run failed:', err);
       setIsLoading(false);
@@ -497,7 +509,7 @@ const App = () => {
     } finally {
       isSynthRunningRef.current = false;
     }
-  }, [currentSessionId, synthSelectionsByRound, uiTabId, findRoundForUserTurn, findExistingSynthesisTurnForRound, findFirstInsertIndexBeforeAi]);
+  }, [currentSessionId, synthSelectionsByRound, uiTabId, findRoundForUserTurn, findExistingSynthesisTurnForRound, findFirstInsertIndexBeforeAi, thinkSynthByRound]);
 
   // Build the Ensembler prompt using provided fixed template from spec
   const buildEnsemblerPrompt = useCallback((userPrompt: string, modelOutputs: Record<string, string>): string => {
@@ -605,7 +617,8 @@ ${modelOutputsBlock}`;
         isVisibleMode,
         uiTabId,
         handlePortMessage,
-        currentSessionId
+        currentSessionId,
+        (ensemblerProvider === 'chatgpt') ? !!thinkEnsembleByRound[userTurnId] : undefined
       );
       lastAttachedPortRef.current = port;
     } catch (err) {
@@ -1060,13 +1073,18 @@ ${modelOutputsBlock}`;
       const handlePortMessage = createPortMessageHandler();
       handlePortMessageRef.current = handlePortMessage;
       
+      const useThinking = (selectedModels['chatgpt'] === true) && Boolean(
+        computeThinkFlag({ modeThinkButtonOn: thinkOnChatGPT, input: prompt })
+      );
+
       const { sessionId, port } = api.executeBatchPrompt(
         prompt,
         activeProviders,
         isVisibleMode,
         uiTabId,
         handlePortMessage,
-        currentSessionId || undefined
+        currentSessionId || undefined,
+        useThinking
       );
       
       setCurrentSessionId(sessionId);
@@ -1092,7 +1110,7 @@ ${modelOutputsBlock}`;
         return newMap;
       });
     }
-  }, [selectedModels, showWelcome, currentSessionId, isVisibleMode, uiTabId, createPortMessageHandler]);
+  }, [selectedModels, showWelcome, currentSessionId, isVisibleMode, uiTabId, createPortMessageHandler, thinkOnChatGPT]);
 
   const handleContinuation = useCallback(async (prompt: string) => {
     const trimmed = prompt.trim();
@@ -1149,12 +1167,17 @@ ${modelOutputsBlock}`;
         lastAttachedPortRef.current = port;
       }
       
+      const useThinking = (selectedModels['chatgpt'] === true) && Boolean(
+        computeThinkFlag({ modeThinkButtonOn: thinkOnChatGPT, input: trimmed })
+      );
+
       await api.executeContinuationPrompt({
         prompt: trimmed,
         providers: providerIds,
         sessionId: currentSessionId,
         providerContexts,
-        uiTabId
+        uiTabId,
+        options: { useThinking }
       });
     } catch (e) {
       console.error('Continuation failed:', e);
@@ -1382,7 +1405,11 @@ ${modelOutputsBlock}`;
               eligibleMap={synthMap}
               ensembleEligibleMap={ensembleMap}
               disableSynthesisRun={disableSynthesisRun}
-              disableEnsembleRun={disableEnsembleRun}
+            disableEnsembleRun={disableEnsembleRun}
+            thinkSynthForChatGPT={!!thinkSynthByRound[turn.id]}
+            onToggleThinkSynthForChatGPT={(rid) => setThinkSynthByRound(prev => ({ ...prev, [rid]: !prev[rid] }))}
+            thinkEnsembleForChatGPT={!!thinkEnsembleByRound[turn.id]}
+            onToggleThinkEnsembleForChatGPT={(rid) => setThinkEnsembleByRound(prev => ({ ...prev, [rid]: !prev[rid] }))}
             />
           </div>
         </div>
@@ -1575,6 +1602,8 @@ ${modelOutputsBlock}`;
           selectedModels={selectedModels}
           onToggleModel={handleToggleModel}
           isLoading={isLoading}
+          thinkOnChatGPT={thinkOnChatGPT}
+          onToggleThinkChatGPT={() => setThinkOnChatGPT(prev => !prev)}
         />
 
         <ChatInput

--- a/ui/components/ModelTray.tsx
+++ b/ui/components/ModelTray.tsx
@@ -5,9 +5,12 @@ interface ModelTrayProps {
   selectedModels: Record<string, boolean>;
   onToggleModel: (providerId: string) => void;
   isLoading?: boolean;
+  // Think-mode (global) toggle for ChatGPT
+  thinkOnChatGPT?: boolean;
+  onToggleThinkChatGPT?: () => void;
 }
 
-const ModelTray = ({ selectedModels, onToggleModel, isLoading = false }: ModelTrayProps) => {
+const ModelTray = ({ selectedModels, onToggleModel, isLoading = false, thinkOnChatGPT = false, onToggleThinkChatGPT }: ModelTrayProps) => {
   return (
     <div
       className="model-tray"
@@ -106,6 +109,32 @@ const ModelTray = ({ selectedModels, onToggleModel, isLoading = false }: ModelTr
           </button>
         );
       })}
+      {/* Global Think toggle for ChatGPT */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginLeft: '8px' }}>
+        <button
+          onClick={() => !isLoading && onToggleThinkChatGPT?.()}
+          disabled={isLoading}
+          title={`Think mode for ChatGPT ${thinkOnChatGPT ? 'ON' : 'OFF'}`}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '6px 10px',
+            background: thinkOnChatGPT ? 'rgba(99, 102, 241, 0.2)' : 'rgba(255, 255, 255, 0.05)',
+            border: `1px solid ${thinkOnChatGPT ? 'rgba(99, 102, 241, 0.4)' : 'rgba(255, 255, 255, 0.1)'}`,
+            borderRadius: '999px',
+            color: thinkOnChatGPT ? '#a5b4fc' : '#64748b',
+            fontSize: '12px',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            transition: 'all 0.2s ease',
+            opacity: isLoading ? 0.6 : 1,
+          }}
+        >
+          <span style={{ fontSize: '14px' }}>🤔</span>
+          <span>Think (ChatGPT)</span>
+          <span style={{ fontSize: '10px', opacity: thinkOnChatGPT ? 1 : 0.7 }}>{thinkOnChatGPT ? 'ON' : 'OFF'}</span>
+        </button>
+      </div>
       
       {/* Active Count Indicator */}
       <div

--- a/ui/components/TurnActionBar.tsx
+++ b/ui/components/TurnActionBar.tsx
@@ -10,11 +10,17 @@ interface TurnActionBarProps {
   synthSelected: Record<string, boolean>;
   onToggleSynth: (roundUserTurnId: string, providerId: string) => void;
   onRunSynthesis: (roundUserTurnId: string) => void;
+  // Think-mode toggle for ChatGPT synthesis
+  thinkSynthForChatGPT?: boolean;
+  onToggleThinkSynthForChatGPT?: (roundUserTurnId: string) => void;
 
   // Ensemble (single-select)
   ensembleSelected: string | null;
   onSelectEnsemble: (roundUserTurnId: string, providerId: string) => void;
   onRunEnsemble: (roundUserTurnId: string) => void;
+  // Think-mode toggle for ChatGPT ensemble
+  thinkEnsembleForChatGPT?: boolean;
+  onToggleThinkEnsembleForChatGPT?: (roundUserTurnId: string) => void;
 
   // Per-provider grey-out
   eligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
@@ -39,6 +45,10 @@ const TurnActionBar = ({
   ensembleEligibleMap = {},
   disableSynthesisRun = false,
   disableEnsembleRun = false,
+  thinkSynthForChatGPT = false,
+  onToggleThinkSynthForChatGPT,
+  thinkEnsembleForChatGPT = false,
+  onToggleThinkEnsembleForChatGPT,
 }: TurnActionBarProps) => {
   const renderToggle = (
     pid: string,
@@ -98,6 +108,26 @@ const TurnActionBar = ({
           const title = block?.reason ? `${p.name}: ${block.reason}` : `Include ${p.name}`;
           return renderToggle(p.id, isSelected, () => onToggleSynth(roundUserTurnId, p.id), isDisabled, title);
         })}
+        {/* Think-mode toggle for ChatGPT synthesis */}
+        <button
+          onClick={() => onToggleThinkSynthForChatGPT?.(roundUserTurnId)}
+          disabled={isLoading}
+          title={`Think mode for ChatGPT ${thinkSynthForChatGPT ? 'ON' : 'OFF'}`}
+          style={{
+            padding: '6px 10px',
+            borderRadius: 999,
+            border: '1px solid #475569',
+            background: thinkSynthForChatGPT ? 'rgba(99,102,241,0.2)' : '#0f172a',
+            color: '#e2e8f0',
+            fontSize: 12,
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6
+          }}
+        >
+          🤔 ChatGPT Think: {thinkSynthForChatGPT ? 'ON' : 'OFF'}
+        </button>
         <div style={{ flex: 1 }} />
         <button
           onClick={() => onRunSynthesis(roundUserTurnId)}
@@ -133,6 +163,26 @@ const TurnActionBar = ({
             '#10b981'
           );
         })}
+        {/* Think-mode toggle for ChatGPT ensemble */}
+        <button
+          onClick={() => onToggleThinkEnsembleForChatGPT?.(roundUserTurnId)}
+          disabled={isLoading}
+          title={`Think mode for ChatGPT ${thinkEnsembleForChatGPT ? 'ON' : 'OFF'}`}
+          style={{
+            padding: '6px 10px',
+            borderRadius: 999,
+            border: '1px solid #475569',
+            background: thinkEnsembleForChatGPT ? 'rgba(99,102,241,0.2)' : '#0f172a',
+            color: '#e2e8f0',
+            fontSize: 12,
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6
+          }}
+        >
+          🤔 ChatGPT Think: {thinkEnsembleForChatGPT ? 'ON' : 'OFF'}
+        </button>
         <div style={{ flex: 1 }} />
         <button
           onClick={() => onRunEnsemble(roundUserTurnId)}

--- a/ui/components/UserTurnBlock.tsx
+++ b/ui/components/UserTurnBlock.tsx
@@ -54,9 +54,14 @@ interface UserTurnBlockProps {
   ensembleEligibleMap?: Record<string, { disabled: boolean; reason?: string }>;
   disableSynthesisRun?: boolean;
   disableEnsembleRun?: boolean;
+  // Think-mode toggles specific to ChatGPT within this round
+  thinkSynthForChatGPT?: boolean;
+  onToggleThinkSynthForChatGPT?: (roundUserTurnId: string) => void;
+  thinkEnsembleForChatGPT?: boolean;
+  onToggleThinkEnsembleForChatGPT?: (roundUserTurnId: string) => void;
 }
 
-const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onToggleSynth, onRunSynthesis, ensembleSelected = null, onSelectEnsemble, onRunEnsemble, eligibleMap = {}, ensembleEligibleMap = {}, disableSynthesisRun = false, disableEnsembleRun = false }: UserTurnBlockProps) => {
+const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onToggleSynth, onRunSynthesis, ensembleSelected = null, onSelectEnsemble, onRunEnsemble, eligibleMap = {}, ensembleEligibleMap = {}, disableSynthesisRun = false, disableEnsembleRun = false, thinkSynthForChatGPT = false, onToggleThinkSynthForChatGPT, thinkEnsembleForChatGPT = false, onToggleThinkEnsembleForChatGPT }: UserTurnBlockProps) => {
   const date = new Date(userTurn.createdAt);
   const readableTimestamp = date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
   const isoTimestamp = date.toISOString();
@@ -173,6 +178,10 @@ const UserTurnBlock = ({ userTurn, isExpanded, onToggle, synthSelected = {}, onT
             ensembleEligibleMap={ensembleEligibleMap}
             disableSynthesisRun={disableSynthesisRun}
             disableEnsembleRun={disableEnsembleRun}
+            thinkSynthForChatGPT={thinkSynthForChatGPT}
+            onToggleThinkSynthForChatGPT={() => onToggleThinkSynthForChatGPT?.(userTurn.id)}
+            thinkEnsembleForChatGPT={thinkEnsembleForChatGPT}
+            onToggleThinkEnsembleForChatGPT={() => onToggleThinkEnsembleForChatGPT?.(userTurn.id)}
           />
         </div>
       </div>

--- a/ui/services/extension-api.ts
+++ b/ui/services/extension-api.ts
@@ -104,7 +104,8 @@ export interface ExtensionApi {
     isVisible: boolean,
     uiTabId?: number,
     onMessage?: (message: any) => void,
-    sessionId?: string
+    sessionId?: string,
+    useThinking?: boolean
   ): { sessionId: string; port: any };
   executeSynthesis(
     sessionId: string,
@@ -112,7 +113,7 @@ export interface ExtensionApi {
     allBatchResults: Record<string, string>,
     synthesisProviders: ('claude' | 'gemini' | 'chatgpt') | Array<'claude' | 'gemini' | 'chatgpt'>,
     uiTabId?: number,
-    options?: { idempotencyToken?: string }
+    options?: { idempotencyToken?: string; useThinking?: boolean }
   ): Promise<void>;
   executeEnsembler(args: {
     sessionId: string;
@@ -121,7 +122,7 @@ export interface ExtensionApi {
     ensemblerProvider: string; // default 'claude'
     ensemblerPrompt: string; // exact prompt provided by UI
     uiTabId?: number;
-    options?: { idempotencyToken?: string };
+    options?: { idempotencyToken?: string; useThinking?: boolean };
   }): Promise<void>;
   executeContinuationPrompt(args: {
     prompt: string;
@@ -312,7 +313,8 @@ const api: ExtensionApi = {
     isVisible: boolean,
     uiTabId?: number,
     onMessage?: (message: any) => void,
-    sessionId?: string
+    sessionId?: string,
+    useThinking?: boolean
   ): { sessionId: string; port: any } {
     const sid = sessionId || `sid-${Date.now()}`;
     
@@ -335,7 +337,9 @@ const api: ExtensionApi = {
       providers: providers.map(p => p.id),
       sessionId: sid,
       uiTabId,
-      executionMode: isVisible ? "visible" : "headless"
+      executionMode: isVisible ? "visible" : "headless",
+      // Forward Think-mode preference for this run (optional)
+      useThinking
     });
 
     console.log("[ExtensionAPI] Sent sendPrompt via port:", { sessionId: sid, providers: providers.map(p => p.id) });
@@ -353,7 +357,7 @@ const api: ExtensionApi = {
     allBatchResults: Record<string, string>,
     synthesisProviders: ("claude" | "gemini" | "chatgpt") | Array<"claude" | "gemini" | "chatgpt">,
     uiTabId?: number,
-    options?: { idempotencyToken?: string }
+    options?: { idempotencyToken?: string; useThinking?: boolean }
   ): Promise<void> {
     // Ensure we have a port; perform reconnect handshake if needed
     const port = await this.ensurePort({ sessionId });
@@ -368,7 +372,8 @@ const api: ExtensionApi = {
         allBatchResults,
         providers,
         uiTabId,
-        idempotencyToken: options?.idempotencyToken
+        idempotencyToken: options?.idempotencyToken,
+        useThinking: options?.useThinking
       });
       console.log("[ExtensionAPI] Sent batch synthesis request via port:", { sessionId, providers });
     } else {
@@ -382,7 +387,8 @@ const api: ExtensionApi = {
         provider: synthesisProvider,
         synthesisProvider,
         uiTabId,
-        idempotencyToken: options?.idempotencyToken
+        idempotencyToken: options?.idempotencyToken,
+        useThinking: options?.useThinking
       });
       console.log("[ExtensionAPI] Sent synthesis request via port:", { sessionId, synthesisProvider });
     }
@@ -406,7 +412,7 @@ const api: ExtensionApi = {
     ensemblerProvider: string;
     ensemblerPrompt: string;
     uiTabId?: number;
-    options?: { idempotencyToken?: string };
+    options?: { idempotencyToken?: string; useThinking?: boolean };
   }): Promise<void> {
     console.log('[ExtensionAPI DEBUG] Entered executeEnsembler');
     const port = await this.ensurePort({ sessionId });
@@ -419,6 +425,7 @@ const api: ExtensionApi = {
       ensemblerPrompt,
       uiTabId,
       idempotencyToken: options?.idempotencyToken,
+      useThinking: options?.useThinking,
     });
     console.log("[ExtensionAPI] Sent ensemble_finalize via port:", { sessionId, ensemblerProvider });
   },
@@ -439,7 +446,7 @@ const api: ExtensionApi = {
     sessionId: string;
     providerContexts: Record<string, any>;
     uiTabId?: number;
-    options?: { idempotencyToken?: string };
+    options?: { idempotencyToken?: string; useThinking?: boolean };
   }): Promise<void> {
     // Ensure we have a port; perform reconnect handshake if needed
     const port = await this.ensurePort({ sessionId });
@@ -452,6 +459,7 @@ const api: ExtensionApi = {
       providerContexts,
       uiTabId,
       idempotencyToken: options?.idempotencyToken,
+      useThinking: options?.useThinking,
     });
     
     console.log("[ExtensionAPI] Sent continuation request via port:", { sessionId, providers, providerContexts });


### PR DESCRIPTION
Implement UI toggles and complete wiring for ChatGPT's "Think mode" across prompts, synthesis, and ensemble.

This PR finishes the end-to-end integration of "Think mode" by adding UI toggles in the `ModelTray` (global) and `TurnActionBar` (per-round for synthesis and ensemble). It wires the `useThinking` flag from these UI controls through `App.tsx` and `extension-api.ts` to the service worker, ensuring the flag is correctly propagated to the ChatGPT adapter for all relevant operations. This enables users to explicitly control when ChatGPT engages its thinking process.

---
<a href="https://cursor.com/background-agent?bcId=bc-29d05e5b-951f-4a92-a079-ed45021dc49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29d05e5b-951f-4a92-a079-ed45021dc49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

